### PR TITLE
Use `setAttribute` instead of `.-className`

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject hipo "0.3.0"
+(defproject hipo "0.3.1-SNAPSHOT"
   :description "ClojureScript DOM templating based on hiccup syntax."
   :url "https://github.com/jeluard/hipo"
   :license {:name "Eclipse Public License"

--- a/src/hipo/compiler.clj
+++ b/src/hipo/compiler.clj
@@ -136,7 +136,7 @@
        ~(when id-keyword
           `(set! (.-id ~el) ~id-keyword))
        ~(when class
-          `(set! (.-className ~el) ~class))
+          `(.setAttribute ~el "class" ~class))
        ~@(for [[k v] (dissoc literal-attrs :class)]
            `(compile-set-attribute!* ~el ~k ~v))
        ~(when var-attrs

--- a/src/hipo/interpreter.cljs
+++ b/src/hipo/interpreter.cljs
@@ -52,7 +52,7 @@
         element-ns (when (+svg-tags+ tag) +svg-ns+)]
     (let [el (dom/create-element element-ns tag)]
       (if class-str
-        (set! (.-className el) class-str))
+        (.setAttribute el "class" class-str))
       (if id
         (set! (.-id el) id))
       (doseq [[k v] (dissoc literal-attrs :class)]

--- a/test/hipo/core_test.cljs
+++ b/test/hipo/core_test.cljs
@@ -25,23 +25,25 @@
         e (hipo/create [:span {:attr (next-id)}])]
     (is (= "1" (.getAttribute e "attr"))))
   (let [e (hipo/create [:div#id {:class "class1 class2"}])]
-    (is (= "class1 class2" (.-className e))))
+    (is (= "class1 class2" (.getAttribute e "class"))))
   (let [e (hipo/create [:div#id.class1 {:class "class2 class3"}])]
-    (is (= "class1 class2 class3" (.-className e))))
+    (is (= "class1 class2 class3" (.getAttribute e "class"))))
+  (let [e (hipo/create [:g {:class "class1"}])]
+    (is (= "class1" (.getAttribute e "class"))))
   (let [cs "class1 class2"
         e (hipo/create [:div ^:attrs (merge {} {:class cs})])]
-    (is (= "class1 class2" (.-className e))))
+    (is (= "class1 class2" (.getAttribute e "class"))))
   (let [cs "class2 class3"
         e (hipo/create [:div (list [:div#id.class1 {:class cs}])])]
     (is (= "class1 class2 class3" (.-className (.-firstChild e)))))
   (let [e (hipo/create [:div.class1 ^:attrs (merge {:data-attr ""} {:class "class2 class3"})])]
-    (is (= "class1 class2 class3" (.-className e))))
+    (is (= "class1 class2 class3" (.getAttribute e "class"))))
   (let [e (hipo/create [:div (interpose [:br] (repeat 3 "test"))])]
     (is (= 5 (.. e -childNodes -length)))
     (is (= "test" (.. e -firstChild -textContent))))
   (let [e (hipo/create [:div.class1 [:span#id1 "span1"] [:span#id2 "span2"]])]
     (is (= "span1span2" (.-textContent e)))
-    (is (= "class1" (.-className e)))
+    (is (= "class1" (.getAttribute e "class")))
     (is (= 2 (-> e .-childNodes .-length)))
     (is (= "<span id=\"id1\">span1</span><span id=\"id2\">span2</span>"
            (.-innerHTML e)))


### PR DESCRIPTION
As per these articles:

http://stackoverflow.com/questions/8638621/jquery-svg-why-cant-i-addclass
http://toddmotto.com/hacking-svg-traversing-with-ease-addclass-removeclass-toggleclass-functions/

The various class-related methods such as `addClass` and `className`
don't work properly with svg tags.

This commit changes the code to use `setAttribute` instead, and
adds a test that validates that setting the class works properly
with a `g` tag.
