### PR TITLE
FIX-#22

### DIFF
--- a/src/hipo/interpreter.cljs
+++ b/src/hipo/interpreter.cljs
@@ -151,7 +151,7 @@
     ; Create new elements if (count nch) > (count oh)
     (if (neg? d)
       (if (identical? -1 d)
-        (if-let [h (nth nch 0)]
+        (if-let [h (nth nch oc)]
           (intercept int :append {:target el :value h}
             (append-child! el h)))
         (let [f (.createDocumentFragment js/document)

--- a/test/hipo/reconciliation_test.cljs
+++ b/test/hipo/reconciliation_test.cljs
@@ -26,3 +26,97 @@
      (is (= (.getAttribute el "class") "class1"))
      (f {:class "class2"})
      (is (= (.getAttribute el "class") "class2")))))
+
+
+
+(deftest list-single-append
+  (testing "List single append"
+    (let [[el f] (hipo/create (fn [m] [:ul (for [i (:items m)] [:li i])]) {:items [1]})]
+      (let [children (.-childNodes el)]
+        (is (= 1 (.-length children)))
+        (let [c (.item children 0)]
+          (is (= "1" (.-textContent c)))))
+      (f {:items [1 2]})
+      (let [children (.-childNodes el)]
+        (is (= 2 (.-length children)))
+        (let [c0 (.item children 0)
+              c1 (.item children 1)]
+          (is (= "1" (.-textContent c0)))
+          (is (= "2" (.-textContent c1)))
+          ))
+      (f {:items [1 2 3]})
+      (let [children (.-childNodes el)]
+        (is (= 3 (.-length children)))
+        (let [c0 (.item children 0)
+              c1 (.item children 1)
+              c2 (.item children 2)
+              ]
+          (is (= "1" (.-textContent c0)))
+          (is (= "2" (.-textContent c1)))
+          (is (= "3" (.-textContent c2)))
+          ))
+      ))
+  (testing "List single prepend"
+    (let [[el f] (hipo/create (fn [m] [:ul (for [i (:items m)] [:li i])]) {:items [1]})]
+      (let [children (.-childNodes el)]
+        (is (= 1 (.-length children)))
+        (let [c (.item children 0)]
+          (is (= "1" (.-textContent c)))))
+      (f {:items [2 1]})
+      (let [children (.-childNodes el)]
+        (is (= 2 (.-length children)))
+        (let [c0 (.item children 0)
+              c1 (.item children 1)]
+          (is (= "2" (.-textContent c0)))
+          (is (= "1" (.-textContent c1)))
+          ))
+      (f {:items [3 2 1]})
+      (let [children (.-childNodes el)]
+        (is (= 3 (.-length children)))
+        (let [c0 (.item children 0)
+              c1 (.item children 1)
+              c2 (.item children 2)
+              ]
+          (is (= "3" (.-textContent c0)))
+          (is (= "2" (.-textContent c1)))
+          (is (= "1" (.-textContent c2)))
+          )))))
+
+(deftest list-multi-append
+  (testing "List multi append"
+    (let [[el f] (hipo/create (fn [m] [:ul (for [i (:items m)] [:li i])]) {:items [1]})]
+      (let [children (.-childNodes el)]
+        (is (= 1 (.-length children)))
+        (let [c (.item children 0)]
+          (is (= "1" (.-textContent c)))))
+      (f {:items [1 2 3]})
+      (let [children (.-childNodes el)]
+        (is (= 3 (.-length children)))
+        (let [c0 (.item children 0)
+              c1 (.item children 1)
+              c2 (.item children 2)
+              ]
+          (is (= "1" (.-textContent c0)))
+          (is (= "2" (.-textContent c1)))
+          (is (= "3" (.-textContent c2)))
+          ))
+      ))
+  (testing "List multi prepend"
+    (let [[el f] (hipo/create (fn [m] [:ul (for [i (:items m)] [:li i])]) {:items [1]})]
+      (let [children (.-childNodes el)]
+        (is (= 1 (.-length children)))
+        (let [c (.item children 0)]
+          (is (= "1" (.-textContent c)))))
+      (f {:items [3 2 1]})
+      (let [children (.-childNodes el)]
+        (is (= 3 (.-length children)))
+        (let [c0 (.item children 0)
+              c1 (.item children 1)
+              c2 (.item children 2)
+              ]
+          (is (= "3" (.-textContent c0)))
+          (is (= "2" (.-textContent c1)))
+          (is (= "1" (.-textContent c2)))
+          )))))
+
+


### PR DESCRIPTION
Fixed in interpreter/update-non-keyed-children!

children incorrectly added for additon of a single child.

See added test cases.

Also added a test case for multi append (> 1 new child).
